### PR TITLE
re-add ability to bind a distinct LDAP DN and Password to enable alias support

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -6,6 +6,8 @@ const ldap = require('ldapjs');
 
 exports.auth = function (config) {
   if (! config.get('ldap_server_url')) throw "Configuration error, you must specifiy an ldap_server_url";
+  if (! config.get('ldap_bind_dn')) throw "Configuration error, you must specifiy a ldap_bind_dn";
+  if (! config.get('ldap_bind_password')) throw "Configuration error, you must specifiy a ldap_bind_password";
 
   return {
 
@@ -52,11 +54,10 @@ exports.auth = function (config) {
         }
       });
 
-      var bindDN = 'mail=' + email + ',o=com,dc=mozilla';
       var results = 0;
       client.bind(
-        bindDN,
-        password,
+        config.get('ldap_bind_dn'),
+        config.get('ldap_bind_password'),
         function(err) {
           if (err) {
             console.error('Unable to bind to LDAP to search for DNs: ' + err.toString());

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -24,10 +24,9 @@ var conf = module.exports = convict({
   },
   http_port: { format: 'int', env: "PORT", default: 3000 },
   issuer: { format: 'string', default: "mozilla.personatest.org" },
-  ldap_server_url: {
-    format: 'string',
-    default: "ldaps://ldap.mozilla.org:636"
-  },
+  ldap_bind_dn: { format: 'string', default: "mail=USERNAME@mozilla.com,o=com,dc=mozilla" },
+  ldap_bind_password: { format: 'string', default: "password" },
+  ldap_server_url: { format: 'string', default: "ldaps://ldap.mozilla.org:636" },
   locale_directory: { format: 'string', default: "locale" },
   statsd: {
     enabled: {


### PR DESCRIPTION
(fixes a regression by @lloyd) - closes #18, related to issue #11
