### PR TITLE
remove last traces of basic auth support, we don't need this right now

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -94,20 +94,6 @@ exports.auth = function (config) {
             });
           }
         });
-    },
-    basic_auth_decode: function (cred, cb) {
-      var pieces = cred.split(' ');
-      if (pieces[0] === 'Basic' && pieces.length === 2) {
-        var decoded = new Buffer(pieces[1], 'base64').toString('utf8');
-        if (decoded.indexOf(':') === -1) {
-          cb("Malformed Basic Authorization [" + decoded + "]", null, null);
-        } else {
-          var parts = decoded.split(':');
-          cb(null, parts[0], parts[1]);
-        }
-      } else {
-        cb("Unknown type of Authentication [" + pieces[0] + "]", null, null);
-      }
     }
   };
 };


### PR DESCRIPTION
For context - this was a feature whereby we would authenticate a user to LDAP inside the persona dialog with a browser dropdown for HTTP basic auth.

The executive decision is to skip this idea for now, and use a web based form that fits in the dialog.  

This patch removes some of the utility libraries required to support the feature.

/cc @mostlygeek r?
