### PR TITLE
Improve detection if called directly or required as a module

### DIFF
--- a/server/bin/clortho
+++ b/server/bin/clortho
@@ -162,7 +162,8 @@ function startup(cb) {
 }
 
 // allow clortho to be invoked from the command line or as a library
-if (process.argv[1] === __filename) {
+// ref: http://stackoverflow.com/a/6398335/445792
+if (require.main === module) {
   // command line invocation
   startup(function(err, address) {
     logger.info(util.format("running on http://%s:%s",


### PR DESCRIPTION
The original method breaks if we use a symlink to point to the repo. This method does not depend on an external system paths.
