### PR TITLE
Fixes #101 by replacing o=com,dc=mozilla with dc=mozilla and extending t...

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -105,9 +105,9 @@ function getUserData(mail, cb) {
         return cb(err, false);
       }
 
-      client.search('o=com,dc=mozilla', {
+      client.search('dc=mozilla', {
         scope: 'sub',
-        filter: '(|(mail='+mail+')(zimbraAlias='+mail+'))',
+        filter: '(&(|(mail='+mail+')(zimbraAlias='+mail+'))(|(o:dn:=org)(o:dn:=com)))',
         attributes: ['mail', 'zimbraAlias', 'employeeType']
       }, function(err, res) {
 


### PR DESCRIPTION
Fixes #101 by replacing o=com,dc=mozilla with dc=mozilla and extending the LDAP filter

Previously, this was searching o=com,dc=mozilla, which excludes some percentage of users who are under o=org,dc=mozilla.

This patch modifies the search in two ways, to search _both_ o=com and o=org.

(1) o=com,dc=mozilla is replaced by dc=mozilla, widening the search scope to include both o=com, o=org, and many other o= results.
(2) The search filter, which previously was (|(mail=?)(zimbraAlias=?)), is extended to also require either o=org or o=com using the approximate syntax (&(|(mail)(zimbraAlias))(|(org)(com)))

If in the future additional filters are required, they would be added as additional () groups inside the outermost (&...) filter, as follows:

(& (|(mail)(zimbraAlias)) (|(org)(com)) (...) )
