### PR TITLE
Make email address field read only after password manager runs. Fixes Issue #104

### DIFF
--- a/server/views/signin.ejs
+++ b/server/views/signin.ejs
@@ -12,7 +12,7 @@
     <div class="center-col">
       <label class="hidden" for="user"><%= gettext("Email address") %></label>
       <input id="user" type="email" name="user" value="<%= email %>"
-             autocorrect="off" autocapitalize="off" disabled="true" />
+             autocorrect="off" autocapitalize="off" />
     </div>
 
 

--- a/static/js/signin.js
+++ b/static/js/signin.js
@@ -3,6 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 $(document).ready(function() {
+
+  setTimeout(function() {
+    $('[name=user]').attr('disabled', 'true');
+  }, 300);
+
   // XXX: currently the server is plucking email out of get data when
   // the auth page is rendered.  It does this to render to the user
   // their substituted email address.


### PR DESCRIPTION
I'm having trouble getting my dev environment completely setup, but I see that this fixes Firefox.

It seems to work with Chrome and 1Password, but I'm not 100% sure.

Uses @mnoorenberghe idea of having a normal email field and making it read only after the page loads and Password Manager has done it's deed.
