### PR TITLE
Detect 3rd party cookies and show an error screen

### DIFF
--- a/server/views/3rd_party_cookies.ejs
+++ b/server/views/3rd_party_cookies.ejs
@@ -1,0 +1,12 @@
+<div class="title">
+  <img src="/i/mozilla-wordmark-200.png" alt="<%= gettext("Mozilla Logo") %>" />
+</div>
+<div class="signin-panel">
+
+  <h1><%= gettext("Error:") %></h1>
+  <p><%= gettext("login.mozilla.org cookies blocked") %></p>
+
+  <p class="error"><%- format(gettext('You need third-party cookies enabled. <a href="%s">Read More</a>.'),
+["https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences?esab=a&s=3rd+party+cookies&r=2&as=s"]) %></p>
+
+</div><!-- #sign-in-panel -->

--- a/static/css/stylo.css
+++ b/static/css/stylo.css
@@ -542,3 +542,11 @@ input:disabled {
   }
 
 }
+
+.error {
+  margin-top: 10px;
+}
+
+.error a {
+  color: #000;
+}


### PR DESCRIPTION
Sets a cookie during the `/provision` request.

Tests for cookie during the `/signin` request. If not present, displays this screen:
![](http://dl.dropbox.com/u/10060532/Screenshots/NUws.png)

Link goes to https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences?esab=a&s=3rd+party+cookies&r=2&as=s
