### PR TITLE
Add a Do Not Track policy

### DIFF
--- a/server/bin/clortho
+++ b/server/bin/clortho
@@ -153,6 +153,12 @@ app.get('/signout', routes.signout);
 app.use(express.static(path.join(process.cwd(), '..', 'static')));
 app.use(routes.handle404);
 
+var dntPolicy = fs.readFileSync(path.join(process.cwd(), '..', 'static', 'dnt-policy.txt')).toString();
+app.get('/.well-known/dnt-policy.txt', function(req, res) {
+  res.setHeader('Content-Type', 'text/plain; charset=utf8');
+  res.send(dntPolicy);
+});
+
 function startup(cb) {
   app.listen(config.get('http_port'), config.get('http_address'), function(err) {
     statsd.increment('server.started');

--- a/static/dnt-policy.txt
+++ b/static/dnt-policy.txt
@@ -1,0 +1,15 @@
+PRELIMINARY DNT POLICY
+
+This domain interprets DNT as a request for an opt out of collection and
+retention of visitors' reading habits, which we will respect, subject to
+reasonable exceptions that respect user privacy. 
+
+This is a temporary document.  A full DNT Policy is being drafted at
+https://eff.org/dnt-policy .  When that document is finished, this domain may
+decide to adopt it.
+
+You can agree to this same policy by posting it at
+https://subdomain.example.com/.well-known/dnt-policy.txt, where "subdomain" is
+any domain to which the policy applies.  Commonly it will be posted on third
+party domains.  HTTPS is required.
+


### PR DESCRIPTION
This will prevent Mozilla IdP from being blocked by privacy-protecting
add-ons such as the EFF's Privacy Badger.

https://www.eff.org/privacybadger#how_to_comply_with_dnt

The temporary policy is copied verbatim from https://www.eff.org/files/dnt-policy-preliminary.txt
